### PR TITLE
CDHSH-85 Load data from from backend into redux store

### DIFF
--- a/services/backend/src/components/profiles/profiles.hooks.js
+++ b/services/backend/src/components/profiles/profiles.hooks.js
@@ -1,4 +1,6 @@
 const {authenticate} = require("@feathersjs/authentication").hooks;
+const dehydrate = require("feathers-sequelize/hooks/dehydrate");
+const {Profile} = require("utils/models");
 
 const includeSkills = () => (context) => {
     const SkillsModel = context.app.services.skills.Model;
@@ -8,6 +10,11 @@ const includeSkills = () => (context) => {
         raw: false
     };
 
+    return context;
+};
+
+const processProfileSkills = () => (context) => {
+    context.result = Profile.processProfileSkills(context.result);
     return context;
 };
 
@@ -24,8 +31,8 @@ module.exports = {
 
     after: {
         all: [],
-        find: [],
-        get: [],
+        find: [dehydrate(), processProfileSkills()],
+        get: [dehydrate(), processProfileSkills()],
         create: [],
         update: [],
         patch: [],

--- a/services/backend/src/db/seedData.js
+++ b/services/backend/src/db/seedData.js
@@ -403,7 +403,11 @@ const PROFILE_SKILLS = [
         id: "9549e841-5466-451c-ad3a-2c46013022f2",
         profileId: PROFILE_IDS_BY_NAME["Sam Heaton"],
         skillId: SKILL_IDS_BY_NAME["Docker"],
+<<<<<<< HEAD
         isHighlySkilled: false,
+=======
+        isHighlySkilled: true,
+>>>>>>> CDHSH-82 Created seed data for profileSkills and implemented skills hook
         createdAt: new Date(),
         updatedAt: new Date()
     },
@@ -419,7 +423,11 @@ const PROFILE_SKILLS = [
         id: "c0103776-26a9-4dc2-84ac-1b7d9d89bac0",
         profileId: PROFILE_IDS_BY_NAME["Sam Heaton"],
         skillId: SKILL_IDS_BY_NAME["JavaScript"],
+<<<<<<< HEAD
         isHighlySkilled: false,
+=======
+        isHighlySkilled: true,
+>>>>>>> CDHSH-82 Created seed data for profileSkills and implemented skills hook
         createdAt: new Date(),
         updatedAt: new Date()
     },
@@ -443,7 +451,11 @@ const PROFILE_SKILLS = [
         id: "a6758a2d-3f24-4116-8eb7-e06b5644766b",
         profileId: PROFILE_IDS_BY_NAME["testBro"],
         skillId: SKILL_IDS_BY_NAME["React"],
+<<<<<<< HEAD
         isHighlySkilled: false,
+=======
+        isHighlySkilled: true,
+>>>>>>> CDHSH-82 Created seed data for profileSkills and implemented skills hook
         createdAt: new Date(),
         updatedAt: new Date()
     },
@@ -459,7 +471,11 @@ const PROFILE_SKILLS = [
         id: "af30de43-4fea-43e2-bb8d-90fd2b195f4a",
         profileId: PROFILE_IDS_BY_NAME["Joshua Gorman"],
         skillId: SKILL_IDS_BY_NAME["Python"],
+<<<<<<< HEAD
         isHighlySkilled: false,
+=======
+        isHighlySkilled: true,
+>>>>>>> CDHSH-82 Created seed data for profileSkills and implemented skills hook
         createdAt: new Date(),
         updatedAt: new Date()
     },
@@ -475,7 +491,11 @@ const PROFILE_SKILLS = [
         id: "b3068dc2-af53-42af-814c-d7db69966d7a",
         profileId: PROFILE_IDS_BY_NAME["Joshua Gorman"],
         skillId: SKILL_IDS_BY_NAME["Docker"],
+<<<<<<< HEAD
         isHighlySkilled: false,
+=======
+        isHighlySkilled: true,
+>>>>>>> CDHSH-82 Created seed data for profileSkills and implemented skills hook
         createdAt: new Date(),
         updatedAt: new Date()
     },

--- a/services/backend/src/db/seedData.js
+++ b/services/backend/src/db/seedData.js
@@ -403,11 +403,7 @@ const PROFILE_SKILLS = [
         id: "9549e841-5466-451c-ad3a-2c46013022f2",
         profileId: PROFILE_IDS_BY_NAME["Sam Heaton"],
         skillId: SKILL_IDS_BY_NAME["Docker"],
-<<<<<<< HEAD
         isHighlySkilled: false,
-=======
-        isHighlySkilled: true,
->>>>>>> CDHSH-82 Created seed data for profileSkills and implemented skills hook
         createdAt: new Date(),
         updatedAt: new Date()
     },
@@ -423,11 +419,7 @@ const PROFILE_SKILLS = [
         id: "c0103776-26a9-4dc2-84ac-1b7d9d89bac0",
         profileId: PROFILE_IDS_BY_NAME["Sam Heaton"],
         skillId: SKILL_IDS_BY_NAME["JavaScript"],
-<<<<<<< HEAD
         isHighlySkilled: false,
-=======
-        isHighlySkilled: true,
->>>>>>> CDHSH-82 Created seed data for profileSkills and implemented skills hook
         createdAt: new Date(),
         updatedAt: new Date()
     },
@@ -451,11 +443,7 @@ const PROFILE_SKILLS = [
         id: "a6758a2d-3f24-4116-8eb7-e06b5644766b",
         profileId: PROFILE_IDS_BY_NAME["testBro"],
         skillId: SKILL_IDS_BY_NAME["React"],
-<<<<<<< HEAD
         isHighlySkilled: false,
-=======
-        isHighlySkilled: true,
->>>>>>> CDHSH-82 Created seed data for profileSkills and implemented skills hook
         createdAt: new Date(),
         updatedAt: new Date()
     },
@@ -471,11 +459,7 @@ const PROFILE_SKILLS = [
         id: "af30de43-4fea-43e2-bb8d-90fd2b195f4a",
         profileId: PROFILE_IDS_BY_NAME["Joshua Gorman"],
         skillId: SKILL_IDS_BY_NAME["Python"],
-<<<<<<< HEAD
         isHighlySkilled: false,
-=======
-        isHighlySkilled: true,
->>>>>>> CDHSH-82 Created seed data for profileSkills and implemented skills hook
         createdAt: new Date(),
         updatedAt: new Date()
     },
@@ -491,11 +475,7 @@ const PROFILE_SKILLS = [
         id: "b3068dc2-af53-42af-814c-d7db69966d7a",
         profileId: PROFILE_IDS_BY_NAME["Joshua Gorman"],
         skillId: SKILL_IDS_BY_NAME["Docker"],
-<<<<<<< HEAD
         isHighlySkilled: false,
-=======
-        isHighlySkilled: true,
->>>>>>> CDHSH-82 Created seed data for profileSkills and implemented skills hook
         createdAt: new Date(),
         updatedAt: new Date()
     },

--- a/services/backend/src/utils/models/Profile.js
+++ b/services/backend/src/utils/models/Profile.js
@@ -1,0 +1,22 @@
+class Profile {
+    /* Extracts the projectProfiles from the associated profile objects
+     * and replaces the profiles as a top-level attribute of the project objects. */
+    static processProfileSkills(profiles = []) {
+        return profiles.map((profile) => {
+            const processedProfile = {...profile};
+            delete processedProfile.skills;
+
+            processedProfile.profileSkills = profile.skills.reduce((acc, {profileSkills}) => {
+                if (profileSkills) {
+                    acc.push(profileSkills);
+                }
+
+                return acc;
+            }, []);
+
+            return processedProfile;
+        });
+    }
+}
+
+module.exports = Profile;

--- a/services/backend/src/utils/models/Profile.test.js
+++ b/services/backend/src/utils/models/Profile.test.js
@@ -1,7 +1,7 @@
 const Profile = require("./Profile");
 
 describe("processProfileSkills", () => {
-    it("takes just the profileSkills and removes the profile data", () => {
+    it("takes just the profileSkills and removes the skill data", () => {
         const profiles = [
             // Multiple profiles at once
             {skills: [{profileSkills: {id: "1"}}, {profileSkills: {id: "3"}}]},

--- a/services/backend/src/utils/models/Profile.test.js
+++ b/services/backend/src/utils/models/Profile.test.js
@@ -1,0 +1,30 @@
+const Profile = require("./Profile");
+
+describe("processProfileSkills", () => {
+    it("takes just the profileSkills and removes the profile data", () => {
+        const profiles = [
+            // Multiple profiles at once
+            {skills: [{profileSkills: {id: "1"}}, {profileSkills: {id: "3"}}]},
+            // Just one profile
+            {skills: [{profileSkills: {id: "2"}}]},
+            // Somehow, there are is a profile with no associated projectProfile
+            {skills: [{}]},
+            // There are no profiles
+            {skills: []}
+        ];
+
+        const processedProfiles = [
+            {profileSkills: [{id: "1"}, {id: "3"}]},
+            {profileSkills: [{id: "2"}]},
+            {profileSkills: []},
+            {profileSkills: []}
+        ];
+
+        expect(Profile.processProfileSkills(profiles)).toEqual(processedProfiles);
+    });
+
+    it("returns an empty array when there are no projects to process", () => {
+        expect(Profile.processProfileSkills()).toEqual([]);
+        expect(Profile.processProfileSkills([])).toEqual([]);
+    });
+});

--- a/services/backend/src/utils/models/index.js
+++ b/services/backend/src/utils/models/index.js
@@ -1,5 +1,7 @@
 const Project = require("./Project");
+const Profile = require("./Profile");
 
 module.exports = {
+    Profile,
     Project
 };

--- a/services/frontend/src/scenes/Profile/Profile.js
+++ b/services/frontend/src/scenes/Profile/Profile.js
@@ -33,7 +33,6 @@ const generateAvatarInitials = (name) => {
 
 const Profile = ({projects = [], profile = {}, isLoading = false}) => {
     if (profile) {
-        profile.skills = dummySkills;
         profile.avatarInitials = generateAvatarInitials(profile.name);
     }
 

--- a/services/frontend/src/scenes/Profile/Profile.js
+++ b/services/frontend/src/scenes/Profile/Profile.js
@@ -2,25 +2,6 @@ import React from "react";
 import ProfileLayout from "./ProfileLayout";
 import connect from "./connect";
 
-const dummySkills = [
-    {
-        name: "Kubernetes",
-        isHighlySkilled: false
-    },
-    {
-        name: "Docker",
-        isHighlySkilled: true
-    },
-    {
-        name: "Django",
-        isHighlySkilled: false
-    },
-    {
-        name: "React",
-        isHighlySkilled: true
-    },
-];
-
 //Split at each word, take the first and last words and then grab their first letters.
 const generateAvatarInitials = (name) => {
     const initials = name.trim().split(" ");

--- a/services/frontend/src/store/crossSliceSelectors.js
+++ b/services/frontend/src/store/crossSliceSelectors.js
@@ -9,6 +9,7 @@ const getProfilesWithSkills = createSelector(
     [
         profilesSlice.selectors.getProfiles,
         profileSkillsSlice.selectors.getById,
+        profileSkillsSlice.selectors.getByProfileId,
         skillsSlice.selectors.getSkills
     ],
     Profile.mergeProfilesWithSkills

--- a/services/frontend/src/store/crossSliceSelectors.js
+++ b/services/frontend/src/store/crossSliceSelectors.js
@@ -3,7 +3,16 @@ import {createSelector} from "redux-starter-kit";
 import {arrayToObject} from "utils/helperFunctions";
 import {Profile, Project, ProjectProfile} from "utils/models";
 import ScreenUrls from "utils/screenUrls";
-import {profilesSlice, projectsSlice, projectProfilesSlice, skillsSlice, userSlice} from "./slices";
+import {profilesSlice, projectsSlice, projectProfilesSlice, skillsSlice, userSlice, profileSkillsSlice} from "./slices";
+
+const getProfilesWithSkills = createSelector(
+    [
+        profilesSlice.selectors.getProfiles,
+        profileSkillsSlice.selectors.getById,
+        skillsSlice.selectors.getSkills
+    ],
+    Profile.mergeProfilesWithSkills
+);
 
 const getProjectsWithSkills = createSelector(
     [projectsSlice.selectors.getProjects, skillsSlice.selectors.getSkills],
@@ -26,7 +35,7 @@ const getProjectFromUrlId = createSelector(
 );
 
 const getUserProfile = createSelector(
-    [profilesSlice.selectors.getProfiles, userSlice.selectors.getUserId],
+    [getProfilesWithSkills, userSlice.selectors.getUserId],
     Profile.getUserProfile
 );
 
@@ -41,6 +50,7 @@ const getProjectsForUser = createSelector(
 );
 
 export const crossSliceSelectors = {
+    getProfilesWithSkills,
     getProjectsWithSkills,
     getProjectsWithSkillsById,
     getProjectIdFromUrl,

--- a/services/frontend/src/store/mountpoints.js
+++ b/services/frontend/src/store/mountpoints.js
@@ -2,6 +2,7 @@ export default {
     authRequests: "authRequests",
     profiles: "profiles",
     profilesRequests: "profilesRequests",
+    profileSkills: "profileSkills",
     projects: "projects",
     projectsRequests: "projectsRequests",
     projectProfiles: "projectProfiles",

--- a/services/frontend/src/store/sagas/profiles.sagas.js
+++ b/services/frontend/src/store/sagas/profiles.sagas.js
@@ -1,13 +1,16 @@
 import {call, fork, put} from "redux-saga/effects";
 import api from "api/";
-import {profilesSlice, profilesRequestsSlice} from "store/slices";
+import {profilesSlice, profilesRequestsSlice, profileSkillsSlice} from "store/slices";
 import {Profile} from "utils/models";
 
 function* profilesFetchAll() {
     const result = yield call(api.service("profiles").find);
+
+    const profileSkills = Profile.extractProfileSkills(result);
     const normalizedProfiles = Profile.normalizeApiResultsForRedux(result);
 
     yield put(profilesSlice.actions.setProfiles(normalizedProfiles));
+    yield put(profileSkillsSlice.actions.addProfileSkills(profileSkills));
 }
 
 function* profilesSaga() {

--- a/services/frontend/src/store/slices/ProfileSkills.slice.test.js
+++ b/services/frontend/src/store/slices/ProfileSkills.slice.test.js
@@ -1,0 +1,49 @@
+import {initialState, profileSkillsSlice} from "./profileSkills.slice";
+import {ProfileSkill} from "utils/models";
+
+describe("reducer", () => {
+    const {actions, reducer} = profileSkillsSlice;
+
+    const profileSkill1 = new ProfileSkill({profileId: "1", skillId: "2"});
+    const profileSkill2 = new ProfileSkill({profileId: "3", skillId: "4"});
+
+    const profileSkills = [profileSkill1, profileSkill2];
+
+    const stateWith1 = {
+        byId: {[profileSkill1.id]: profileSkill1},
+        byProfileId: {[profileSkill1.profileId]: [profileSkill1.id]},
+        bySkillId: {[profileSkill1.skillId]: [profileSkill1.id]}
+    };
+
+    const stateWithAll = {
+        byId: {
+            [profileSkill1.id]: profileSkill1,
+            [profileSkill2.id]: profileSkill2
+        },
+        byProfileId: {
+            [profileSkill1.profileId]: [profileSkill1.id],
+            [profileSkill2.profileId]: [profileSkill2.id]
+        },
+        bySkillId: {
+            [profileSkill1.skillId]: [profileSkill1.id],
+            [profileSkill2.skillId]: [profileSkill2.id],
+        }
+    };
+
+    it("can add a single profile skill at a time", () => {
+        expect(reducer(undefined, actions.addProfileSkill(profileSkill1))).toEqual(stateWith1);
+        expect(reducer(stateWith1, actions.addProfileSkill(profileSkill2))).toEqual(stateWithAll);
+    });
+
+    it("can add multiple profile skills at once", () => {
+        expect(reducer(undefined, actions.addProfileSkills(profileSkills))).toEqual(stateWithAll);
+    });
+
+    it("doesn't duplicate anything when adding an existing profile skills again", () => {
+        expect(reducer(stateWith1, actions.addProfileSkill(profileSkill1))).toEqual(stateWith1);
+    });
+
+    it("doesn't duplicate anything when adding multiple existing profile skills again", () => {
+        expect(reducer(stateWithAll, actions.addProfileSkills(profileSkills))).toEqual(stateWithAll);
+    });
+});

--- a/services/frontend/src/store/slices/index.js
+++ b/services/frontend/src/store/slices/index.js
@@ -1,5 +1,6 @@
 export {authRequestsSlice} from "./auth.slice";
 export {profilesSlice, profilesRequestsSlice} from "./profiles.slice";
+export {profileSkillsSlice} from "./profileSkills.slice";
 export {projectsSlice, projectsRequestsSlice} from "./projects.slice";
 export {projectProfilesSlice} from "./projectProfiles.slice";
 export {skillsSlice, skillsRequestsSlice} from "./skills.slice";

--- a/services/frontend/src/store/slices/profileSkills.slice.js
+++ b/services/frontend/src/store/slices/profileSkills.slice.js
@@ -1,0 +1,63 @@
+import {createSelector, createSlice} from "redux-starter-kit";
+import mounts from "store/mountpoints";
+
+export const initialState = {
+    // byId stores the whole ProfileSkill object, keyed by ID
+    // i.e. {[id]: ProfileSkill}
+    byId: {},
+    // bySkillId stores references (lists of IDs) of ProfileSkills objects, keyed by their skillId
+    // i.e. {[skillId]: [ProfileSkill.id]}
+    bySkillId: {},
+};
+
+const addProfileSkillId = (state, action) => {
+    // Expects an object like {foreignId: "", id: ""} as payload,
+    // where 'foreignId' is a skillId,
+    // and 'id' is a ProfileSkill ID
+    const {payload} = action;
+    const {id, foreignId} = payload;
+
+    if (!state[foreignId]) {
+        state[foreignId] = [];
+    }
+
+    if (!state[foreignId].includes(id)) {
+        state[foreignId].push(id);
+    }
+};
+
+const addProfileSkill= (state, action) => {
+    const {payload} = action;
+    const {id, skillId} = payload;
+
+    state.byId[id] = payload;
+
+    addProfileSkillId(state.bySkillId, {payload: {id, foreignId: skillId}});
+};
+
+export const profileSkillsSlice = createSlice({
+    slice: mounts.profileSkills,
+    initialState,
+    reducers: {
+        addProfileSkill,
+        addProfileSkills: (state, action) => {
+            action.payload.forEach((profileSkill) => addProfileSkill(state, {payload: profileSkill}));
+        }
+    }
+});
+
+const getById = createSelector(
+    [profileSkillsSlice.selectors.getProfileSkills],
+    (profileSkills) => profileSkills.byId
+);
+
+const getBySkillId = createSelector(
+    [profileSkillsSlice.selectors.getProfileSkills],
+    (profileSkills) => profileSkills.bySkillId
+);
+
+profileSkillsSlice.selectors = {
+    ...profileSkillsSlice.selectors,
+    getById,
+    getBySkillId
+};

--- a/services/frontend/src/store/slices/profileSkills.slice.js
+++ b/services/frontend/src/store/slices/profileSkills.slice.js
@@ -5,6 +5,9 @@ export const initialState = {
     // byId stores the whole ProfileSkill object, keyed by ID
     // i.e. {[id]: ProfileSkill}
     byId: {},
+    // byProfileId stores references (lists of IDs) of ProfileSkills objects, keyed by their profileId
+    // i.e. {[profileid]: [ProfileSkill.id]}
+    byProfileId: {},
     // bySkillId stores references (lists of IDs) of ProfileSkills objects, keyed by their skillId
     // i.e. {[skillId]: [ProfileSkill.id]}
     bySkillId: {},
@@ -26,13 +29,14 @@ const addProfileSkillId = (state, action) => {
     }
 };
 
-const addProfileSkill= (state, action) => {
+const addProfileSkill = (state, action) => {
     const {payload} = action;
-    const {id, skillId} = payload;
+    const {id, profileId, skillId} = payload;
 
     state.byId[id] = payload;
 
     addProfileSkillId(state.bySkillId, {payload: {id, foreignId: skillId}});
+    addProfileSkillId(state.byProfileId, {payload: {id, foreignId: profileId}});
 };
 
 export const profileSkillsSlice = createSlice({
@@ -51,6 +55,11 @@ const getById = createSelector(
     (profileSkills) => profileSkills.byId
 );
 
+const getByProfileId = createSelector(
+    [profileSkillsSlice.selectors.getProfileSkills],
+    (profileSkills) => profileSkills.byProfileId
+);
+
 const getBySkillId = createSelector(
     [profileSkillsSlice.selectors.getProfileSkills],
     (profileSkills) => profileSkills.bySkillId
@@ -59,5 +68,6 @@ const getBySkillId = createSelector(
 profileSkillsSlice.selectors = {
     ...profileSkillsSlice.selectors,
     getById,
+    getByProfileId,
     getBySkillId
 };

--- a/services/frontend/src/utils/models/Profile.js
+++ b/services/frontend/src/utils/models/Profile.js
@@ -69,7 +69,7 @@ export default class Profile {
     static mergeProfilesWithSkills(
         profilesById = {}, profileSkillsById = {}, profileSkillsByProfileId = {}, skillsById = {}
     ) {
-        const profileWithSkills = Object.keys(profilesById).map((profileId) => {
+        const profilesWithSkills = Object.keys(profilesById).map((profileId) => {
             /* get the profileSkills for a given profile */
             const profile = {...profilesById[profileId]};
             const profileSkills = ProfileSkill.mapProfileIdToProfileSkills(
@@ -82,9 +82,8 @@ export default class Profile {
                     const skill = new Skill({...skillsById[profileSkill.skillId]});
                     skill.isHighlySkilled = profileSkill.isHighlySkilled;
                     acc = [...acc, skill];
-
-                    return acc;
                 }
+                return acc;
             }, []);
 
             /* Delete the unneeded profileSkills and return profile */
@@ -92,6 +91,6 @@ export default class Profile {
             return profile;
         });
 
-        return profileWithSkills;
+        return profilesWithSkills;
     }
 }

--- a/services/frontend/src/utils/models/Profile.js
+++ b/services/frontend/src/utils/models/Profile.js
@@ -13,6 +13,7 @@ export default class Profile {
         userId = uuidv4(),
         createdAt = new Date(),
         updatedAt = new Date(),
+        profileSkills = []
     } = {}) {
         this.id = id;
         this.name = name;
@@ -24,13 +25,31 @@ export default class Profile {
         this.userId = userId;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+
+        // Temporary related properties; might exist from API results, but aren't used past initial processing
+        this.profileSkills = profileSkills;
     }
 
     /* Normalizes the list of profiles that the API returns into a map of {ID -> Profile},
      * with the skills processed to just their IDs, for appropriate use in the Redux store. */
     static normalizeApiResultsForRedux(profiles = []) {
-        const processProfile = (profile) => new Profile(profile);
+        const processProfile = (profile) => {
+            const processedProfile = new Profile(profile)
+
+            if (processedProfile.profileSkills) {
+                processedProfile.profileSkills = processedProfile.profileSkills.map(({id}) => id);
+            } else {
+                processedProfile.profileSkills = [];
+            }
+
+            return processedProfile;
+        }
+
         return profiles.reduce(arrayToObject(processProfile), {});
+    }
+
+    static extractProfileSkills(profiles = []) {
+        return profiles.reduce((acc, profile) => [...acc, ...profile.profileSkills], []);
     }
 
     /* Iterate over profiles checking for the current user's id, then return that user's entire profile. */
@@ -43,4 +62,50 @@ export default class Profile {
 
         return foundProfileIndex ? profilesById[foundProfileIndex] : null;
     }
+
+
+    /* Takes profiles, profileSkills and Skills.
+    grabs all of the profileSkills objects from a profile and merges them with the skills objects */
+    static mergeProfilesWithSkills(profilesById = {}, profileSkillsById = {}, skillsById = {}) {
+        //console.log(profilesById)
+        //console.log(profileSkillsById)
+        //console.log(skillsById)
+        const profileWithSkills = Object.keys(profilesById).map((profileId) => {
+            const profile = {...profilesById[profileId]};
+
+            profile.profileSkills = getProfileSkills(profile, profileSkillsById);
+            profile.skills = mergeProfileSkillWithSkill(profile, skillsById);
+
+            delete profile.profileSkills;
+            return profile;
+        });
+
+        return profileWithSkills;
+    }
 }
+
+/* Take in a profile and array of profileSkills.
+Return an array of all profileSkills in the profile */
+const getProfileSkills = (profile, profileSkillsById = {}) => (
+    profile.profileSkills.reduce((acc, profileSkillId) => {
+        if (profileSkillId in profileSkillsById) {
+            acc = [...acc, profileSkillsById[profileSkillId]];
+        }
+
+        return acc;
+    }, [])
+);
+
+/* Take in a profile and an array of skills.
+return an array of combined profileSkills and skills. */
+const mergeProfileSkillWithSkill = (profile, skillsById) => (
+    profile.profileSkills.reduce((acc, profileSkill) => {
+        const skillId = profileSkill.skillId;
+
+        if (skillId in skillsById) {
+            skillsById[skillId].isHighlySkilled = profileSkill.isHighlySkilled;
+            acc = [...acc, skillsById[skillId]];
+        }
+        return acc;
+    }, [])
+);

--- a/services/frontend/src/utils/models/Profile.test.js
+++ b/services/frontend/src/utils/models/Profile.test.js
@@ -1,6 +1,4 @@
-import Profile from "./Profile";
-import ProfileSkill from "./ProfileSkill";
-import Skill from "./Skill";
+import {Profile, ProfileSkill, Skill} from "utils/models";
 
 describe("normalizeApiResultsForRedux", () => {
     const ProfilesList = [
@@ -17,7 +15,7 @@ describe("normalizeApiResultsForRedux", () => {
         [ProfilesList[3].id]: {...ProfilesList[3], profileSkills: []}
     };
 
-    it("normalizes a list of Profiles to a map of Profiles with just skill IDs", () => {
+    it("normalizes a list of Profiles to a map of Profiles with just profileSkill IDs", () => {
         expect(Profile.normalizeApiResultsForRedux(ProfilesList)).toEqual(ProfilesMap);
     });
 });

--- a/services/frontend/src/utils/models/Profile.test.js
+++ b/services/frontend/src/utils/models/Profile.test.js
@@ -88,23 +88,27 @@ describe("mergeProfilesWithSkills", () => {
     combinedSkill3.isHighlySkilled = true;
 
     const profiles = {[Profile1.id]: Profile1, [Profile2.id]: Profile2};
-    const profileSkills = {[profileSkill1.id]: profileSkill1, 
-        [profileSkill2.id]: profileSkill2, 
+    const profileSkills = {[profileSkill1.id]: profileSkill1,
+        [profileSkill2.id]: profileSkill2,
         [profileSkill3.id]: profileSkill3,
         [profileSkill4.id]: profileSkill4
     };
+    const profileSkillsByProfileId = {[Profile1.id]: [profileSkill1.id, profileSkill2.id],
+        [Profile2.id]: [profileSkill3.id, profileSkill4.id]
+    };
     const skills = {[skillA.id]: skillA, [skillB.id]: skillB, [skillC.id]: skillC};
 
-
     const Profile1WithSkills = {...Profile1, skills: [combinedSkill1, combinedSkill2]};
-    delete Profile1WithSkills.profileSkills
+    delete Profile1WithSkills.profileSkills;
     const Profile2WithSkills = {...Profile2, skills: [combinedSkill2, combinedSkill3]};
-    delete Profile2WithSkills.profileSkills
+    delete Profile2WithSkills.profileSkills;
 
     const ProfilesWithSkills = [Profile1WithSkills, Profile2WithSkills];
 
     it("can merge a set of Profiles with a set of skills (while ignoring unknown skills)", () => {
-        expect(Profile.mergeProfilesWithSkills(profiles, profileSkills, skills)).toEqual(ProfilesWithSkills);
+        expect(Profile.mergeProfilesWithSkills(
+            profiles, profileSkills, profileSkillsByProfileId, skills
+        )).toEqual(ProfilesWithSkills);
     });
 
     it("returns an empty array when given empty inputs", () => {

--- a/services/frontend/src/utils/models/ProfileSkill.js
+++ b/services/frontend/src/utils/models/ProfileSkill.js
@@ -1,0 +1,15 @@
+import uuidv4 from "uuid/v4";
+
+export default class ProfileSkill {
+    constructor({
+        id = uuidv4(), profileId = null, skillId = null, isHighlySkilled = false,
+        createdAt = new Date(), updatedAt = new Date()
+    } = {}) {
+        this.id = id;
+        this.profileId = profileId;
+        this.skillId = skillId;
+        this.isHighlySkilled = isHighlySkilled;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/services/frontend/src/utils/models/ProfileSkill.js
+++ b/services/frontend/src/utils/models/ProfileSkill.js
@@ -12,4 +12,42 @@ export default class ProfileSkill {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
+
+    static mapProfileIdToProfileSkills(profileId, byId, byProfileId) {
+        return mapForeignIdToProfileSkills(profileId, byId, byProfileId);
+    }
+
+    static mapSkillIdToProfileSkills(skillId, byId, bySkillId) {
+        return mapForeignIdToProfileSkills(skillId, byId, bySkillId);
+    }
+
+    static mapProfileSkillsToProfiles(profileSkills, profilesById) {
+        return mapProfileSkillsToForeignModel("profileId", profileSkills, profilesById);
+    }
+
+    static mapProfileSkillsToSkills(profileSkills, skillsById) {
+        return mapProfileSkillsToForeignModel("skillId", profileSkills, skillsById);
+    }
 }
+
+const mapForeignIdToProfileSkills = (foreignId, byId, byForeignId) => {
+    if (foreignId in byForeignId) {
+        return byForeignId[foreignId].map((id) => byId[id]);
+    }
+
+    return [];
+};
+
+const mapProfileSkillsToForeignModel = (foreignKey, profileSkills, foreignModelsById) => {
+    const addedIds = {};
+
+    return profileSkills.reduce((acc, {[foreignKey]: foreignId}) => {
+        if (foreignId in foreignModelsById && !(foreignId in addedIds)) {
+            acc = [...acc, foreignModelsById[foreignId]];
+            addedIds[foreignId] = true;
+        }
+
+        return acc;
+    }, []);
+};
+

--- a/services/frontend/src/utils/models/ProfileSkill.test.js
+++ b/services/frontend/src/utils/models/ProfileSkill.test.js
@@ -1,0 +1,93 @@
+import {Profile, ProfileSkill, Skill} from "utils/models";
+
+const profile = new Profile({id: "1", profileSkills: ["a", "b"]});
+
+const profilesById = {
+    [profile.id]: profile,
+};
+
+const skill1 = new Skill();
+const skill2 = new Skill();
+
+const skillsById = {
+    [skill1.id]: skill1,
+    [skill2.id]: skill2
+};
+
+const profileSkill1 = new ProfileSkill({profileId: profile.id, skillId: skill1.id});
+const profileSkill2 = new ProfileSkill({profileId: profile.id, skillId: skill2.id});
+
+const profileSkillsById = {
+    [profileSkill1.id]: profileSkill1,
+    [profileSkill2.id]: profileSkill2
+};
+
+const profileSkillsByProfileId = {
+    [profile.id]: [profileSkill1.id, profileSkill2.id]
+};
+
+const profileSkillsBySkillId = {
+    [skill1.id]: [profileSkill1.id],
+    [skill2.id]: [profileSkill2.id]
+};
+
+const profiles = [profile];
+const skills = [skill1, skill2];
+const profileSkills = [profileSkill1, profileSkill2];
+
+describe("mapProfileIdToProfileSkills", () => {
+    it("can map a profile ID to a list of profile skills", () => {
+        expect(ProfileSkill.mapProfileIdToProfileSkills(
+            profile.id, profileSkillsById, profileSkillsByProfileId
+        )).toEqual(profileSkills);
+    });
+
+    it("returns an empty array when the profile ID is invalid", () => {
+        expect(ProfileSkill.mapProfileIdToProfileSkills(
+            "abc", profileSkillsById, profileSkillsByProfileId
+        )).toEqual([]);
+    });
+});
+
+describe("mapSkillIdToProfileSkills", () => {
+    it("can map a skill ID to a list of profile skills", () => {
+        expect(ProfileSkill.mapSkillIdToProfileSkills(
+            skill1.id, profileSkillsById, profileSkillsBySkillId
+        )).toEqual([profileSkill1]);
+    });
+
+    it("returns an empty array when the skill ID is invalid", () => {
+        expect(ProfileSkill.mapSkillIdToProfileSkills(
+            "abc", profileSkillsById, profileSkillsBySkillId
+        )).toEqual([]);
+    });
+});
+
+describe("mapProfileSkillsToProfiles", () => {
+    it("can map a list of profile skills into a list of profiles", () => {
+        expect(ProfileSkill.mapProfileSkillsToProfiles(
+            profileSkills, profilesById
+        )).toEqual(profiles);
+    });
+
+    it("returns an empty array when the no profile is found", () => {
+        expect(ProfileSkill.mapProfileSkillsToProfiles(
+            [new ProfileSkill()], profilesById
+        )).toEqual([]);
+    });
+});
+
+describe("mapProfileSkillsToSkills", () => {
+    it("can map a list of profile skills into a list of skills", () => {
+        expect(ProfileSkill.mapProfileSkillsToSkills(
+            profileSkills, skillsById
+        )).toEqual(skills);
+    });
+
+    it("returns an empty array when the no skill is found", () => {
+        expect(ProfileSkill.mapProfileSkillsToSkills(
+            [new ProfileSkill()], skillsById
+        )).toEqual([]);
+    });
+});
+

--- a/services/frontend/src/utils/models/index.js
+++ b/services/frontend/src/utils/models/index.js
@@ -1,4 +1,5 @@
 export {default as Profile} from "./Profile";
+export {default as ProfileSkill} from "./ProfileSkill";
 export {default as Project} from "./Project";
 export {default as ProjectProfile} from "./ProjectProfile";
 export {default as Skill} from "./Skill";


### PR DESCRIPTION
Changelog:
- filled the redux store with full skill data
- updated frontend view to have full skill data (Solves CDHSH-86)

Implementation Details:
- deletion of line 36 in `src/scenes/Profile/Profile.js` solves CDHSH-86 (load data from redux into profile view)
- loaded profileSkills into the redux store with selectors byId, byProfileId and bySkillId
- added mapping functions to map profileSkills byId, byProfileId and bySkillId.
- changed crossSliceSelector for getUserProfile to use the profiles with full skill information
- added crossSliceSelector for getting all user profiles with full skill information
- added tests for business logic