### PR TITLE
CDHSH-27 Implemented people pages and fixed profile loading.

### DIFF
--- a/services/frontend/src/AppRouter.js
+++ b/services/frontend/src/AppRouter.js
@@ -9,6 +9,7 @@ const AppRouter = () => (
         <Navbar />
         <Switch>
             <Route path={ScreenUrls.PROFILE} component={Profile} />
+            <Route path={ScreenUrls.PEOPLE_DETAILS} component={Profile} />
             <Route path={ScreenUrls.PEOPLE} component={People} />
             <Route path={ScreenUrls.PROJECT_DETAILS} component={ProjectDetails} />
             <Route path={ScreenUrls.PROJECTS} component={Projects} />

--- a/services/frontend/src/components/AvatarIcon/AvatarIcon.js
+++ b/services/frontend/src/components/AvatarIcon/AvatarIcon.js
@@ -2,9 +2,9 @@ import React from "react";
 import {Avatar, Tooltip} from "@material-ui/core";
 import "./AvatarIcon.scss";
 
-const AvatarIcon = ({name, role, className}) => (
+const AvatarIcon = ({name, personsRole, className}) => (
     <div className="avatar-icon-content">
-        <Tooltip title={role} placement={"top"} disableHoverListener={(role === undefined)}>
+        <Tooltip title={personsRole} placement={"top"} disableHoverListener={(personsRole === undefined)}>
             <Avatar className={className}>
                 {generateAvatarInitials(name)}
             </Avatar>

--- a/services/frontend/src/components/AvatarIcon/AvatarIcon.js
+++ b/services/frontend/src/components/AvatarIcon/AvatarIcon.js
@@ -2,10 +2,10 @@ import React from "react";
 import {Avatar, Tooltip} from "@material-ui/core";
 import "./AvatarIcon.scss";
 
-const AvatarIcon = ({name, role}) => (
+const AvatarIcon = ({name, role, className}) => (
     <div className="avatar-icon-content">
         <Tooltip title={role} placement={"top"} disableHoverListener={(role === undefined)}>
-            <Avatar className="avatar-icon">
+            <Avatar className={className}>
                 {generateAvatarInitials(name)}
             </Avatar>
         </Tooltip>

--- a/services/frontend/src/components/LoadingValidator/LoadingValidator.js
+++ b/services/frontend/src/components/LoadingValidator/LoadingValidator.js
@@ -20,15 +20,17 @@ const emptyDependency = (dependencies) => dependencies.reduce((acc, currentDepen
 
 /* Shows a circular progress loader if the component is currently loading,
 renders an inputted component (componentOnFailedLoad) if one of the dependencies is empty */
-const LoadingValidator = ({isLoading, children, renderOnFailedLoad, dependencies}) => (
-    (isLoading || missingDependency(dependencies)) ? (
-        <CircularProgress className="loading-button-indicator" />
-    ) : (
-        emptyDependency(dependencies) ? (
+const LoadingValidator = ({isLoading, renderOnLoad, renderOnFailedLoad, dependencies}) => {
+    if (isLoading || missingDependency(dependencies)) {
+        return <CircularProgress className="loading-indicator" />;
+    }
+    else {
+        return (emptyDependency(dependencies)) ? (
             renderOnFailedLoad
         ) : (
-            children
-        )
-    )
-);
+            renderOnLoad
+        );
+    }
+};
+
 export default LoadingValidator;

--- a/services/frontend/src/components/LoadingValidator/LoadingValidator.js
+++ b/services/frontend/src/components/LoadingValidator/LoadingValidator.js
@@ -1,0 +1,34 @@
+import React from "react";
+import {CircularProgress} from "@material-ui/core";
+import "./LoadingValidator.scss";
+
+/* Check if any of our dependencies haven't been loaded up yet */
+const missingDependency = (dependencies) => dependencies.reduce((acc, currentDependency) => {
+    return acc || !currentDependency;
+}, false);
+
+/* Check if any of our dependencies have no data to be loaded into the page */
+const emptyDependency = (dependencies) => dependencies.reduce((acc, currentDependency) => {
+    if (currentDependency.isArray) {
+        return acc || (currentDependency.length === 0);
+    }
+    else if (typeof currentDependency === "object") {
+        return acc || (Object.keys(currentDependency).length === 0);
+    }
+    return acc;
+}, false);
+
+/* Shows a circular progress loader if the component is currently loading,
+renders an inputted component (componentOnFailedLoad) if one of the dependencies is empty */
+const LoadingValidator = ({isLoading, children, renderOnFailedLoad, dependencies}) => (
+    (isLoading || missingDependency(dependencies)) ? (
+        <CircularProgress className="loading-button-indicator" />
+    ) : (
+        emptyDependency(dependencies) ? (
+            renderOnFailedLoad
+        ) : (
+            children
+        )
+    )
+);
+export default LoadingValidator;

--- a/services/frontend/src/components/LoadingValidator/LoadingValidator.scss
+++ b/services/frontend/src/components/LoadingValidator/LoadingValidator.scss
@@ -1,12 +1,7 @@
 @import "styles/_colors.scss";
 @import "styles/_dimens.scss";
 
-.loading-button {
-    .loading-button-indicator {
-        color: $color-light;
-
-        /* Need to override Material-UI's inline styles */
-        height: 24px !important;  
-        width: 24px !important;
-    }
+.loading-indicator {
+    align-self: center;
+    justify-self: center;
 }

--- a/services/frontend/src/components/LoadingValidator/LoadingValidator.scss
+++ b/services/frontend/src/components/LoadingValidator/LoadingValidator.scss
@@ -1,0 +1,12 @@
+@import "styles/_colors.scss";
+@import "styles/_dimens.scss";
+
+.loading-button {
+    .loading-button-indicator {
+        color: $color-light;
+
+        /* Need to override Material-UI's inline styles */
+        height: 24px !important;  
+        width: 24px !important;
+    }
+}

--- a/services/frontend/src/components/LoadingValidator/index.js
+++ b/services/frontend/src/components/LoadingValidator/index.js
@@ -1,0 +1,1 @@
+export {default} from "./LoadingValidator";

--- a/services/frontend/src/components/ScrollContainer/ScrollContainer.scss
+++ b/services/frontend/src/components/ScrollContainer/ScrollContainer.scss
@@ -15,11 +15,6 @@
         min-width: $minimum-width;
         padding: 0 $default-spacing;
 
-        .loading-button-indicator {
-            align-self: center;
-            justify-self: center;
-        }
-
         @include laptop-width {
             & {
                 max-width: $laptop-width;

--- a/services/frontend/src/components/index.js
+++ b/services/frontend/src/components/index.js
@@ -4,6 +4,7 @@ export {default as AuthForm} from "./AuthForm";
 export {default as EmailInput} from "./EmailInput";
 export {default as FormError} from "./FormError";
 export {default as LoadingButton} from "./LoadingButton";
+export {default as LoadingValidator} from "./LoadingValidator";
 export {default as Navbar} from "./Navbar";
 export {default as NavSidebar} from "./NavSidebar";
 export {default as ProjectCard} from "./ProjectCard";

--- a/services/frontend/src/scenes/Profile/Profile.js
+++ b/services/frontend/src/scenes/Profile/Profile.js
@@ -2,15 +2,12 @@ import React from "react";
 import ProfileLayout from "./ProfileLayout";
 import connect from "./connect";
 
-const Profile = ({projects = [], profile = {}, isLoading = false}) => {
-
-    return (
-        <ProfileLayout
-            projects={projects}
-            profile={profile}
-            profileLoading={isLoading}
-        />
-    );
-};
+const Profile = ({projects = [], profile = {}, isLoading = false}) => (
+    <ProfileLayout
+        projects={projects}
+        profile={profile}
+        isLoading={isLoading}
+    />
+);
 
 export default connect(Profile);

--- a/services/frontend/src/scenes/Profile/Profile.scss
+++ b/services/frontend/src/scenes/Profile/Profile.scss
@@ -112,6 +112,12 @@
             margin: $default-spacing 0;
             width: auto;
 
+            @include max-laptop-width {
+                .project-card-content-section{
+                    margin-left: $default-spacing;
+                }
+            }
+
             &:first-child {
                 margin-top: 0;
             }

--- a/services/frontend/src/scenes/Profile/Profile.scss
+++ b/services/frontend/src/scenes/Profile/Profile.scss
@@ -19,6 +19,17 @@
     }
 }
 
+.invalid-profile {
+    justify-self: center;
+    align-self: center;
+    padding: $default-spacing * 1.5;
+    text-align: center;
+
+    .invalid-profile-heading {
+        font-size: $font-size-title;
+    }
+}
+
 .profile-card {
     display: flex;
     flex: 1;
@@ -34,7 +45,7 @@
     .profile-card-personal-details {
         flex: 1;
 
-        .avatar-icon {
+        .profile-avatar-icon {
             font-size: 30px;
             height: 64px;
             width: 64px;

--- a/services/frontend/src/scenes/Profile/ProfileLayout.js
+++ b/services/frontend/src/scenes/Profile/ProfileLayout.js
@@ -28,18 +28,23 @@ const ProfileLayout = ({projects, profile, isLoading}) => (
     <ScrollContainer className="profile">
         <LoadingValidator
             dependencies={[profile]}
-            renderOnFailedLoad={InvalidProfile()}
             isLoading={isLoading}
-        >
-            <NavSidebar
-                scrollSpySelectors={sections}
-                containerClass={containerClass}
-            />
-            <ProfileContent
-                projects={projects}
-                profile={profile}
-            />
-        </LoadingValidator>
+            renderOnLoad={
+                <>
+                    <NavSidebar
+                        scrollSpySelectors={sections}
+                        containerClass={containerClass}
+                    />
+                    <ProfileContent
+                        projects={projects}
+                        profile={profile}
+                    />
+                </>
+            }
+            renderOnFailedLoad={
+                <InvalidProfile />
+            }
+        />
     </ScrollContainer>
 );
 

--- a/services/frontend/src/scenes/Profile/ProfileLayout.js
+++ b/services/frontend/src/scenes/Profile/ProfileLayout.js
@@ -1,8 +1,10 @@
 import React, {useMemo} from "react";
-import {Avatar, CircularProgress, Paper} from "@material-ui/core";
+import {Link} from "react-router-dom";
+import {Avatar, Button, Paper} from "@material-ui/core";
 import {Email, LocalPhone} from "@material-ui/icons";
-import {AvatarIcon, NavSidebar, ProjectCard, ScrollContainer, SkillBadges} from "components/";
+import {AvatarIcon, LoadingValidator, NavSidebar, ProjectCard, ScrollContainer, SkillBadges} from "components/";
 import {Project} from "utils/models";
+import ScreenUrls from "utils/screenUrls";
 import "./Profile.scss";
 
 const containerClass = ".scroll-container";
@@ -24,23 +26,34 @@ const sections = [
 
 const ProfileLayout = ({projects, profile, isLoading}) => (
     <ScrollContainer className="profile">
-        {
-            (!profile || isLoading) ? (
-                <CircularProgress className="loading-button-indicator" />
-            ) : (
-                <>
-                    <NavSidebar
-                        scrollSpySelectors={sections}
-                        containerClass={containerClass}
-                    />
-                    <ProfileContent
-                        projects={projects}
-                        profile={profile}
-                    />
-                </>
-            )
-        }
+        <LoadingValidator
+            dependencies={[profile]}
+            renderOnFailedLoad={InvalidProfile()}
+            isLoading={isLoading}
+        >
+            <NavSidebar
+                scrollSpySelectors={sections}
+                containerClass={containerClass}
+            />
+            <ProfileContent
+                projects={projects}
+                profile={profile}
+            />
+        </LoadingValidator>
     </ScrollContainer>
+);
+
+const InvalidProfile = () => (
+    <Paper className="invalid-profile">
+        <h2 className="invalid-profile-heading">
+            Content Not Found
+        </h2>
+        <Link to={ScreenUrls.PEOPLE}>
+            <Button color="primary">
+                Back to People
+            </Button>
+        </Link>
+    </Paper>
 );
 
 const ProfileContent = ({...sectionProps}) => (
@@ -70,7 +83,7 @@ const renderSectionComponent = (sectionName, sectionProps) => {
 
 const PersonalDetails = ({profile}) => (
     <Paper className="profile-card profile-card-personal-details">
-        <AvatarIcon name={profile.name} className="avatar-icon" />
+        <AvatarIcon name={profile.name} className="profile-avatar-icon" />
         <div className="profile-card-content">
             <h2 className="profile-card-title">
                 {profile.name}

--- a/services/frontend/src/scenes/Profile/ProfileLayout.js
+++ b/services/frontend/src/scenes/Profile/ProfileLayout.js
@@ -1,6 +1,6 @@
 import React, {useMemo} from "react";
 import {Link} from "react-router-dom";
-import {Avatar, Button, Paper} from "@material-ui/core";
+import {Button, Paper} from "@material-ui/core";
 import {Email, LocalPhone} from "@material-ui/icons";
 import {AvatarIcon, LoadingValidator, NavSidebar, ProjectCard, ScrollContainer, SkillBadges} from "components/";
 import {Project} from "utils/models";
@@ -88,7 +88,7 @@ const renderSectionComponent = (sectionName, sectionProps) => {
 
 const PersonalDetails = ({profile}) => (
     <Paper className="profile-card profile-card-personal-details">
-        <AvatarIcon name={profile.name} className="profile-avatar-icon" />
+        <AvatarIcon name={profile.name} personsRole="" className="profile-avatar-icon" />
         <div className="profile-card-content">
             <h2 className="profile-card-title">
                 {profile.name}

--- a/services/frontend/src/scenes/Profile/connect.js
+++ b/services/frontend/src/scenes/Profile/connect.js
@@ -1,11 +1,40 @@
 import {connect} from "react-redux";
+import {matchPath} from "react-router";
 import {crossSliceSelectors} from "store/";
 import {profilesRequestsSlice} from "store/slices";
+import ScreenUrls from "utils/screenUrls";
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, props) => {
+    if (matchPath(props.match.path, ScreenUrls.PROFILE)) {
+        return {
+            projects: crossSliceSelectors.getProjectsForUser(state),
+            profile: crossSliceSelectors.getUserProfile(state)
+        };
+    }
+    else {
+        const personProfile = crossSliceSelectors.getProfileFromUrlId(state);
+
+        return personProfile ? {
+            isLoading: profilesRequestsSlice.fetchAll.selectors.getLoading(state),
+            projects: crossSliceSelectors.getProjectsFromUrlId(state),
+            profile: personProfile
+        } : (
+            props.history.push("/404")
+        );
+    }
+
+    /*
+    return {
     isLoading: profilesRequestsSlice.fetchAll.selectors.getLoading(state),
-    projects: crossSliceSelectors.getProjectsForUser(state),
-    profile: crossSliceSelectors.getUserProfile(state)
-});
+
+    ...(matchPath(props.match.pathName, ScreenUrls.PROFILE) ? ({
+        projects: crossSliceSelectors.getProjectsForUser(state),
+        profile: crossSliceSelectors.getUserProfile(state)
+    }) : ({
+        projects: crossSliceSelectors.getProjectsForUser(state),
+        profile: crossSliceSelectors.getProfileFromUrlId(state)
+    }))
+    */
+};
 
 export default connect(mapStateToProps, null);

--- a/services/frontend/src/scenes/Profile/connect.js
+++ b/services/frontend/src/scenes/Profile/connect.js
@@ -1,40 +1,35 @@
 import {connect} from "react-redux";
 import {matchPath} from "react-router";
 import {crossSliceSelectors} from "store/";
-import {profilesRequestsSlice} from "store/slices";
+import {reduceLoadingStates} from "utils/helperFunctions";
+import {profilesRequestsSlice, projectsRequestsSlice, skillsRequestsSlice} from "store/slices";
 import ScreenUrls from "utils/screenUrls";
 
 const mapStateToProps = (state, props) => {
+    const mappedState = {};
+    mappedState.isLoading = reduceLoadingStates([
+        profilesRequestsSlice,
+        projectsRequestsSlice,
+        skillsRequestsSlice
+    ], state);
+
     if (matchPath(props.match.path, ScreenUrls.PROFILE)) {
-        return {
-            projects: crossSliceSelectors.getProjectsForUser(state),
-            profile: crossSliceSelectors.getUserProfile(state)
-        };
+        mappedState.projects = crossSliceSelectors.getProjectsForUser(state);
+        mappedState.profile = crossSliceSelectors.getUserProfile(state);
+
+    } else {
+        const loadedProfile = crossSliceSelectors.getProfileFromUrlId(state);
+
+        if (loadedProfile) {
+            mappedState.profile = loadedProfile;
+            mappedState.projects = crossSliceSelectors.getProjectsFromUrlId(state);
+
+        } else {
+            mappedState.profile = {};
+            mappedState.projects = [];
+        }
     }
-    else {
-        const personProfile = crossSliceSelectors.getProfileFromUrlId(state);
-
-        return personProfile ? {
-            isLoading: profilesRequestsSlice.fetchAll.selectors.getLoading(state),
-            projects: crossSliceSelectors.getProjectsFromUrlId(state),
-            profile: personProfile
-        } : (
-            props.history.push("/404")
-        );
-    }
-
-    /*
-    return {
-    isLoading: profilesRequestsSlice.fetchAll.selectors.getLoading(state),
-
-    ...(matchPath(props.match.pathName, ScreenUrls.PROFILE) ? ({
-        projects: crossSliceSelectors.getProjectsForUser(state),
-        profile: crossSliceSelectors.getUserProfile(state)
-    }) : ({
-        projects: crossSliceSelectors.getProjectsForUser(state),
-        profile: crossSliceSelectors.getProfileFromUrlId(state)
-    }))
-    */
+    return mappedState;
 };
 
 export default connect(mapStateToProps, null);

--- a/services/frontend/src/scenes/Profile/connect.js
+++ b/services/frontend/src/scenes/Profile/connect.js
@@ -1,11 +1,10 @@
 import {connect} from "react-redux";
-import {matchPath} from "react-router";
 import {crossSliceSelectors} from "store/";
 import {reduceLoadingStates} from "utils/helperFunctions";
 import {profilesRequestsSlice, projectsRequestsSlice, skillsRequestsSlice} from "store/slices";
 import ScreenUrls from "utils/screenUrls";
 
-const mapStateToProps = (state, props) => {
+const mapStateToProps = (state) => {
     const mappedState = {};
     mappedState.isLoading = reduceLoadingStates([
         profilesRequestsSlice,
@@ -13,7 +12,7 @@ const mapStateToProps = (state, props) => {
         skillsRequestsSlice
     ], state);
 
-    if (matchPath(props.match.path, ScreenUrls.PROFILE)) {
+    if (crossSliceSelectors.isMatchingRoute(ScreenUrls.PROFILE)(state)) {
         mappedState.projects = crossSliceSelectors.getProjectsForUser(state);
         mappedState.profile = crossSliceSelectors.getUserProfile(state);
 
@@ -22,7 +21,7 @@ const mapStateToProps = (state, props) => {
 
         if (loadedProfile) {
             mappedState.profile = loadedProfile;
-            mappedState.projects = crossSliceSelectors.getProjectsFromUrlId(state);
+            mappedState.projects = crossSliceSelectors.getProjectsFromProfileUrlId(state);
 
         } else {
             mappedState.profile = {};

--- a/services/frontend/src/scenes/ProjectDetails/ProjectDetailsLayout.js
+++ b/services/frontend/src/scenes/ProjectDetails/ProjectDetailsLayout.js
@@ -114,7 +114,11 @@ const Contributors = ({sectionName, contributors}) => {
                 {contributors.map((contributor) => {
                     return (
                         <div className="project-contributors-badge" key={contributor.name}>
-                            <AvatarIcon name={contributor.name} role={contributor.role} />
+                            <AvatarIcon
+                                name={contributor.name}
+                                personsRole={contributor.role}
+                                className="avatar-icon"
+                            />
                             <h3 className="project-contributors-badge-name">{contributor.name}</h3>
                         </div>
                     );

--- a/services/frontend/src/store/crossSliceSelectors.js
+++ b/services/frontend/src/store/crossSliceSelectors.js
@@ -31,6 +31,11 @@ const getProfileFromUrlId = createSelector(
     (profilesById, profileId) => profilesById[profileId]
 );
 
+const getUserProfile = createSelector(
+    [getProfilesWithSkills, userSlice.selectors.getUserId],
+    Profile.getUserProfile
+);
+
 /* Project Selectors */
 const getProjectsWithSkills = createSelector(
     [projectsSlice.selectors.getProjects, skillsSlice.selectors.getSkills],
@@ -53,11 +58,6 @@ const getProjectFromUrlId = createSelector(
 );
 
 /* Other Selectors */
-const getUserProfile = createSelector(
-    [getProfilesWithSkills, userSlice.selectors.getUserId],
-    Profile.getUserProfile
-);
-
 const getContributorsForProject = createSelector(
     [
         getProjectIdFromUrl,
@@ -93,11 +93,11 @@ export const crossSliceSelectors = {
     getProfilesWithSkillsById,
     getProfileIdFromUrl,
     getProfileFromUrlId,
+    getUserProfile,
     getProjectsWithSkills,
     getProjectsWithSkillsById,
     getProjectIdFromUrl,
     getProjectsFromUrlId,
-    getUserProfile,
     getContributorsForProject,
     getProjectFromUrlId,
     getProjectsForUser

--- a/services/frontend/src/store/crossSliceSelectors.js
+++ b/services/frontend/src/store/crossSliceSelectors.js
@@ -5,6 +5,7 @@ import {Profile, Project, ProjectProfile} from "utils/models";
 import ScreenUrls from "utils/screenUrls";
 import {profilesSlice, projectsSlice, projectProfilesSlice, skillsSlice, userSlice, profileSkillsSlice} from "./slices";
 
+/* Profile Selectors */
 const getProfilesWithSkills = createSelector(
     [
         profilesSlice.selectors.getProfiles,
@@ -15,6 +16,22 @@ const getProfilesWithSkills = createSelector(
     Profile.mergeProfilesWithSkills
 );
 
+const getProfilesWithSkillsById = createSelector(
+    [getProfilesWithSkills],
+    (profilesWithSkills) => profilesWithSkills.reduce(arrayToObject(), {})
+);
+
+const getProfileIdFromUrl = createSelector(
+    [createMatchSelector(ScreenUrls.PEOPLE_DETAILS)],
+    (match) => match.params.id
+);
+
+const getProfileFromUrlId = createSelector(
+    [getProfilesWithSkillsById, getProfileIdFromUrl],
+    (profilesById, profileId) => profilesById[profileId]
+);
+
+/* Project Selectors */
 const getProjectsWithSkills = createSelector(
     [projectsSlice.selectors.getProjects, skillsSlice.selectors.getSkills],
     Project.mergeWithSkills
@@ -35,6 +52,7 @@ const getProjectFromUrlId = createSelector(
     (projectsById, projectId) => projectsById[projectId]
 );
 
+/* Other Selectors */
 const getUserProfile = createSelector(
     [getProfilesWithSkills, userSlice.selectors.getUserId],
     Profile.getUserProfile
@@ -50,6 +68,16 @@ const getContributorsForProject = createSelector(
     Project.getContributors
 );
 
+const getProjectsFromUrlId = createSelector(
+    [
+        getProfileFromUrlId,
+        getProjectsWithSkillsById,
+        projectProfilesSlice.selectors.getById,
+        projectProfilesSlice.selectors.getByProfileId
+    ],
+    ProjectProfile.mapProfileToProjects
+);
+
 const getProjectsForUser = createSelector(
     [
         getUserProfile,
@@ -62,11 +90,15 @@ const getProjectsForUser = createSelector(
 
 export const crossSliceSelectors = {
     getProfilesWithSkills,
+    getProfilesWithSkillsById,
+    getProfileIdFromUrl,
+    getProfileFromUrlId,
     getProjectsWithSkills,
     getProjectsWithSkillsById,
     getProjectIdFromUrl,
-    getProjectFromUrlId,
+    getProjectsFromUrlId,
     getUserProfile,
-    getProjectsForUser,
-    getContributorsForProject
+    getContributorsForProject,
+    getProjectFromUrlId,
+    getProjectsForUser
 };

--- a/services/frontend/src/store/crossSliceSelectors.js
+++ b/services/frontend/src/store/crossSliceSelectors.js
@@ -5,10 +5,7 @@ import {Profile, Project, ProjectProfile} from "utils/models";
 import ScreenUrls from "utils/screenUrls";
 import {profilesSlice, projectsSlice, projectProfilesSlice, skillsSlice, userSlice, profileSkillsSlice} from "./slices";
 
-const isMatchingRoute = (route) => createSelector(
-    [createMatchSelector(route)],
-    (match) => match
-);
+const isMatchingRoute = createMatchSelector;
 
 /* Profile Selectors */
 const getProfilesWithSkills = createSelector(

--- a/services/frontend/src/store/crossSliceSelectors.js
+++ b/services/frontend/src/store/crossSliceSelectors.js
@@ -5,6 +5,11 @@ import {Profile, Project, ProjectProfile} from "utils/models";
 import ScreenUrls from "utils/screenUrls";
 import {profilesSlice, projectsSlice, projectProfilesSlice, skillsSlice, userSlice, profileSkillsSlice} from "./slices";
 
+const isMatchingRoute = (route) => createSelector(
+    [createMatchSelector(route)],
+    (match) => match
+);
+
 /* Profile Selectors */
 const getProfilesWithSkills = createSelector(
     [
@@ -68,7 +73,7 @@ const getContributorsForProject = createSelector(
     Project.getContributors
 );
 
-const getProjectsFromUrlId = createSelector(
+const getProjectsFromProfileUrlId = createSelector(
     [
         getProfileFromUrlId,
         getProjectsWithSkillsById,
@@ -89,6 +94,7 @@ const getProjectsForUser = createSelector(
 );
 
 export const crossSliceSelectors = {
+    isMatchingRoute,
     getProfilesWithSkills,
     getProfilesWithSkillsById,
     getProfileIdFromUrl,
@@ -97,8 +103,8 @@ export const crossSliceSelectors = {
     getProjectsWithSkills,
     getProjectsWithSkillsById,
     getProjectIdFromUrl,
-    getProjectsFromUrlId,
-    getContributorsForProject,
     getProjectFromUrlId,
+    getContributorsForProject,
+    getProjectsFromProfileUrlId,
     getProjectsForUser
 };

--- a/services/frontend/src/styles/_media_queries.scss
+++ b/services/frontend/src/styles/_media_queries.scss
@@ -17,6 +17,12 @@ $laptop-height: 767px;
     }
 }
 
+@mixin max-laptop-width {
+    @media (max-width: #{$laptop-width}) {
+        @content
+    }
+}
+
 @mixin desktop-width {
     @media (min-width: #{$desktop-width}) {
         @content

--- a/services/frontend/src/utils/helperFunctions.js
+++ b/services/frontend/src/utils/helperFunctions.js
@@ -7,3 +7,9 @@ export const arrayToObject = ({processor = identity, property = "id"} = {}) => (
 
     return acc;
 };
+
+export const reduceLoadingStates = (slices, state) => (
+    slices.reduce((acc, slice) => (
+        acc || slice.fetchAll.selectors.getLoading(state)
+    ), false)
+);

--- a/services/frontend/src/utils/models/Profile.test.js
+++ b/services/frontend/src/utils/models/Profile.test.js
@@ -1,5 +1,20 @@
 import {Profile, ProfileSkill, Skill} from "utils/models";
 
+/* Mock the date so "createdAt" and "updatedAt" properties will not be invalid if created at different times */
+const realDate = Date;
+const constantDate = new Date("2019-01-01T12:00:00");
+
+global.Date = class extends Date {
+    constructor () {
+        return constantDate;
+    }
+};
+
+/* Set the date object back to it's normal value */
+afterAll(() => {
+    global.Date = realDate;
+});
+
 describe("normalizeApiResultsForRedux", () => {
     const ProfilesList = [
         new Profile({id: "1", profileSkills: [{id: "a"}, {id: "b"}]}),

--- a/services/frontend/src/utils/screenUrls.js
+++ b/services/frontend/src/utils/screenUrls.js
@@ -4,6 +4,7 @@ const ScreenUrls = {
     LOGIN: "/login",
     PROFILE: "/app/profile",
     PEOPLE: "/app/people",
+    PEOPLE_DETAILS: "/app/people/:id",
     PROJECTS: "/app/projects",
     PROJECT_DETAILS: "/app/projects/:id",
     SIGN_UP: "/signup"


### PR DESCRIPTION
Changelog:
- Fixed loading bar for people/profile pages to show load all sections before showing
- Loaded pages for all users on /app/people/:id
- Setup simple `InvalidProfile` component to be rendered if no user is found

Other Implementation Details:
- Added date mocking to profile tests to fix `updatedAt` and `createdAt` inconsistencies.
- Moved profile loading to component `LoadingValidator` to be reusable for other pages. 
- Added conditional state mapping to `scenes/Profile/connect.js` to handle `app/people/:id` and `app/profile` separately.
- Added profile selectors to `getByUrl` and get projects for any user.