### PR TITLE
CDHSH-104 Fixed typo for which variable to use when doing the 'latest project update' fetch request.

### DIFF
--- a/services/scraper/src/scrapers/JiraScraper.js
+++ b/services/scraper/src/scrapers/JiraScraper.js
@@ -178,7 +178,7 @@ class JiraScraper {
         const path = getPath(this.platform, "getProjectsLastUpdated");
         const fullPath = `${path}&jql=project=${projectKey}+order+by+updated+desc`;
 
-        const response = await this.axios.get(path);
+        const response = await this.axios.get(fullPath);
         const issues = response.data.issues;
 
         if (issues.length) {


### PR DESCRIPTION
Changelog:

- 'lastActive' times are now correctly populated when scraping projects.