### PR TITLE
CDHSH-120 Created the basic Openshift manifests that enable the Scraper to be deployed to the cluster.

### DIFF
--- a/manifests/openshift/scraper/build-config.yaml
+++ b/manifests/openshift/scraper/build-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+    name: scraper
+    labels:
+        app: skillhub
+spec:
+    source:
+        git:
+            uri: https://github.com/CDH-Studio/skillhub.git
+            ref: "master"
+        contextDir: "services/scraper"
+    strategy:
+        type: Docker
+    output:
+        to:
+            kind: ImageStreamTag
+            name: "scraper:latest"

--- a/manifests/openshift/scraper/deployment-config.yaml
+++ b/manifests/openshift/scraper/deployment-config.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+    name: scraper
+    labels:
+        app: skillhub
+        run: scraper
+spec:
+    replicas: 1
+    selector:
+        run: scraper
+    template:
+        metadata:
+            labels:
+                run: scraper
+        spec:
+            containers:
+            - name: scraper
+              image: docker-registry.default.svc:5000/skillhub/scraper:latest
+              imagePullPolicy: Always
+              ports:
+              - containerPort: 5000
+                protocol: TCP
+              env:
+              - name: BACKEND_PORT
+                value: "80"
+              - name: BACKEND_HOST
+                value: "backend.skillhub.ca"
+              - name: JIRA_HOST
+                value: "https://jira.ised-isde.canada.ca"
+              - name: JIRA_PLATFORM
+                value: "server"
+              - name: BACKEND_PROTOCOL
+                value: "https"
+              - name: JIRA_AUTH_TOKEN
+                valueFrom:
+                    secretKeyRef:
+                        name: scraper-secrets
+                        key: JIRA_AUTH_TOKEN
+              - name: SKILLHUB_API_KEY
+                valueFrom:
+                    secretKeyRef:
+                        name: scraper-secrets
+                        key: SKILLHUB_API_KEY
+            restartPolicy: Always
+    triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChangeParams:
+          automatic: true
+          containerNames:
+          - scraper
+          from:
+              kind: ImageStreamTag
+              name: "scraper:latest"
+

--- a/manifests/openshift/scraper/image-stream.yaml
+++ b/manifests/openshift/scraper/image-stream.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ImageStream
+metadata:
+    name: scraper
+    labels:
+        app: skillhub

--- a/manifests/openshift/scraper/route.yaml
+++ b/manifests/openshift/scraper/route.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Route
+metadata:
+    name: scraper
+    labels:
+        app: skillhub
+        run: scraper
+spec:
+    host: scraper-skillhub.apps.ic.gc.ca
+    port:
+        targetPort: 5000-tcp
+    tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: edge
+    to:
+        kind: Service
+        name: scraper
+        weight: 100
+    wildcardPolicy: None

--- a/manifests/openshift/scraper/service.yaml
+++ b/manifests/openshift/scraper/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: scraper
+    labels:
+        app: skillhub
+        run: scraper
+spec:
+    ports:
+    - name: 5000-tcp
+      protocol: TCP
+      port: 5000
+    targetPort: 5000
+    selector:
+        run: scraper
+    type: ClusterIP


### PR DESCRIPTION
Changelog:

- Scraper can now be deployed to Openshift.

Other Implementation Details:

- N/A

Reviewer Notes:

- Ya, there ain't much to be reviewed here...