### PR TITLE
CDHSH-127 Modified the Scraper to use Redis workers for async processing of contributors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ It runs on port `5001`.
 The Scraper has been setup so that it has one route that triggers all of its scraping activities: `/scraper`. You can hit this route locally with something like:
 
 ```
-curl localhost:5001/scraper
+curl localhost:5001/scraper/contributors
 ```
 
 To run the Scraper on a deployed branch or production, just change the host:
 
 ```
-curl https://cdhsh-XX.scraper.skillhub.ca/scraper
+curl https://cdhsh-XX.scraper.skillhub.ca/scraper/contributors
 ```
 
 This fully exposed, non-authenticated endpoint is merely to ease our development and testing processes.

--- a/helm/templates/build-config-os.yaml
+++ b/helm/templates/build-config-os.yaml
@@ -6,7 +6,8 @@
 
 {{- $tag := "latest"}}
 {{- $branch := .Values.tag | default "master"}}
-{{- $imageStreamTag := printf "%s:%s" $serviceName $tag}}
+{{- $imageName := index $serviceMap "image"}}
+{{- $imageStreamTag := printf "%s:%s" $imageName $tag}}
 
 apiVersion: v1
 kind: BuildConfig

--- a/helm/templates/deployment-config-os.yaml
+++ b/helm/templates/deployment-config-os.yaml
@@ -12,6 +12,8 @@
 {{- $image := (index $serviceMap "image_in_project") | ternary $projectImage $serviceImage}}
 {{- $imageStreamTag := printf "%s:%s" $serviceName $tag}}
 
+{{- $command := index $serviceMap "command"}}
+
 {{- $env := index $serviceMap "env"}}
 
 {{- $waitForService := index $serviceMap "wait_for_service"}}
@@ -41,6 +43,14 @@ spec:
               imagePullPolicy: Always
               ports:
               - containerPort: {{index $serviceMap "container_port"}}
+
+              {{- if $command}}
+              command:
+                {{- range $command}}
+                - {{. | quote}}
+                {{- end}}
+              {{- end}}
+
               env:
               {{- range $key, $value := .Values.__services}}
               - name: {{$key | upper | replace "-" "_"}}_PORT

--- a/helm/templates/deployment-os.yaml
+++ b/helm/templates/deployment-os.yaml
@@ -11,6 +11,8 @@
 {{- $projectImage := printf "gcr.io/%s/%s-%s:%s" .Values.__gcp_project_id .Values.__project_name $serviceImage $tag}}
 {{- $image := (index $serviceMap "image_in_project") | ternary $projectImage $serviceImage}}
 
+{{- $command := index $serviceMap "command"}}
+
 {{- $env := index $serviceMap "env"}}
 
 {{- $pvClaimName := printf "%s-pv-claim" $serviceName}}
@@ -67,6 +69,14 @@ spec:
                 name: {{$serviceName}}
                 ports:
                   - containerPort: {{index $serviceMap "container_port"}}
+
+                {{- if $command}}
+                command:
+                  {{- range $command}}
+                  - {{. | quote}}
+                  {{- end}}
+                {{- end}}
+
                 env:
                   {{- range $key, $value := .Values.__services}}
                   - name: {{$key | upper | replace "-" "_"}}_PORT

--- a/helm/templates/deployment-os.yaml
+++ b/helm/templates/deployment-os.yaml
@@ -8,7 +8,7 @@
 
 {{- $tag := "latest"}}
 {{- $serviceImage := index $serviceMap "image"}}
-{{- $projectImage := printf "gcr.io/%s/%s-%s:%s" .Values.__gcp_project_id .Values.__project_name $serviceImage $tag}}
+{{- $projectImage := printf "docker-registry.default.svc:5000/%s/%s:%s" .Values.__gcp_project_id $serviceImage $tag}}
 {{- $image := (index $serviceMap "image_in_project") | ternary $projectImage $serviceImage}}
 
 {{- $command := index $serviceMap "command"}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -11,6 +11,8 @@
 {{- $projectImage := printf "gcr.io/%s/%s-%s:%s" .Values.__gcp_project_id .Values.__project_name $serviceImage .Values.tag}}
 {{- $image := (index $serviceMap "image_in_project") | ternary $projectImage $serviceImage}}
 
+{{- $command := index $serviceMap "command"}}
+
 {{- $env := index $serviceMap "env"}}
 
 {{- $pvClaimName := printf "%s-pv-claim" $serviceName}}
@@ -66,6 +68,14 @@ spec:
                 name: {{$serviceName}}
                 ports:
                   - containerPort: {{index $serviceMap "container_port"}}
+
+                {{- if $command}}
+                command:
+                  {{- range $command}}
+                  - {{. | quote}}
+                  {{- end}}
+                {{- end}}
+
                 env:
                   - name: NAMESPACE
                     value: {{$namespace}}

--- a/helm/templates/image-stream-os.yaml
+++ b/helm/templates/image-stream-os.yaml
@@ -1,11 +1,13 @@
 {{- if and .Values.__services .Values.serviceName}}
 {{- $projectName := .Values.__project_name}}
 {{- $serviceName := .Values.serviceName}}
+{{- $serviceMap := index .Values.__services $serviceName}}
+{{- $imageName := index $serviceMap "image"}}
 
 apiVersion: v1
 kind: ImageStream
 metadata:
-    name: {{$serviceName}}
+    name: {{$imageName}}
     labels:
         app: {{$projectName}}
 {{- end}}

--- a/kubails.json
+++ b/kubails.json
@@ -236,7 +236,7 @@
                 "deployment"
             ],
             "type": "",
-            "wait_for_service": null
+            "wait_for_service": "redis"
         }
     },
     "__wildcard_certificate_secret": "skillhub-tls"

--- a/kubails.json
+++ b/kubails.json
@@ -137,6 +137,26 @@
             "type": "NodePort",
             "wait_for_service": null
         },
+        "redis": {
+            "container_port": "6379",
+            "env": [],
+            "external_port": "6379",
+            "folder": null,
+            "host": "redis",
+            "image": "redis",
+            "image_in_project": false,
+            "persistent_volume": {},
+            "pre_startup_command": null,
+            "production_replicas": 1,
+            "replicas": 1,
+            "secrets": {},
+            "templates": [
+                "deployment",
+                "service"
+            ],
+            "type": "ClusterIP",
+            "wait_for_service": null
+        },
         "scraper": {
             "container_port": "5000",
             "env": [
@@ -202,7 +222,7 @@
             "image_in_project": true,
             "persistent_volume": {},
             "pre_startup_command": "",
-            "production_replicas": 1,
+            "production_replicas": 2,
             "replicas": 1,
             "secrets": {
                 "file": ".env.encrypted",

--- a/kubails.json
+++ b/kubails.json
@@ -177,6 +177,46 @@
             ],
             "type": "NodePort",
             "wait_for_service": null
+        },
+        "scraper-worker": {
+            "command": ["npm", "run", "worker"],
+            "container_port": "5000",
+            "env": [
+                {
+                    "name": "JIRA_HOST",
+                    "value": "https://jira.ised-isde.canada.ca"
+                },
+                {
+                    "name": "JIRA_PLATFORM",
+                    "value": "server"
+                },
+                {
+                    "name": "BACKEND_PROTOCOL",
+                    "value": "https"
+                }
+            ],
+            "external_port": null,
+            "folder": "scraper",
+            "host": null,
+            "image": "scraper",
+            "image_in_project": true,
+            "persistent_volume": {},
+            "pre_startup_command": "",
+            "production_replicas": 1,
+            "replicas": 1,
+            "secrets": {
+                "file": ".env.encrypted",
+                "name": "scraper-secrets",
+                "variables": [
+                    "JIRA_AUTH_TOKEN",
+                    "SKILLHUB_API_KEY"
+                ]
+            },
+            "templates": [
+                "deployment"
+            ],
+            "type": "",
+            "wait_for_service": null
         }
     },
     "__wildcard_certificate_secret": "skillhub-tls"

--- a/kubails.openshift.json
+++ b/kubails.openshift.json
@@ -143,6 +143,26 @@
             "type": "NodePort",
             "wait_for_service": null
         },
+        "redis": {
+            "container_port": "6379",
+            "env": [],
+            "external_port": "6379",
+            "folder": null,
+            "host": "redis",
+            "image": "redis",
+            "image_in_project": false,
+            "persistent_volume": {},
+            "pre_startup_command": null,
+            "production_replicas": 1,
+            "replicas": 1,
+            "secrets": {},
+            "templates": [
+                "deployment-os",
+                "service-os"
+            ],
+            "type": "ClusterIP",
+            "wait_for_service": null
+        },
         "scraper": {
             "container_port": "5000",
             "env": [
@@ -185,6 +205,46 @@
             ],
             "type": "NodePort",
             "wait_for_service": null
+        },
+        "scraper-worker": {
+            "command": ["npm", "run", "worker"],
+            "container_port": "5000",
+            "env": [
+                {
+                    "name": "JIRA_HOST",
+                    "value": "https://jira.ised-isde.canada.ca"
+                },
+                {
+                    "name": "JIRA_PLATFORM",
+                    "value": "server"
+                },
+                {
+                    "name": "BACKEND_PROTOCOL",
+                    "value": "https"
+                }
+            ],
+            "external_port": null,
+            "folder": "scraper",
+            "host": null,
+            "image": "scraper",
+            "image_in_project": true,
+            "persistent_volume": {},
+            "pre_startup_command": "",
+            "production_replicas": 2,
+            "replicas": 1,
+            "secrets": {
+                "file": ".env.encrypted",
+                "name": "scraper-secrets",
+                "variables": [
+                    "JIRA_AUTH_TOKEN",
+                    "SKILLHUB_API_KEY"
+                ]
+            },
+            "templates": [
+                "deployment-os"
+            ],
+            "type": "",
+            "wait_for_service": "redis"
         }
     },
     "__wildcard_certificate_secret": "skillhub-tls"

--- a/services/backend/package-lock.json
+++ b/services/backend/package-lock.json
@@ -1505,6 +1505,14 @@
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -3461,7 +3469,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3482,12 +3491,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3502,17 +3513,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3629,7 +3643,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3641,6 +3656,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3655,6 +3671,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3662,12 +3679,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3686,6 +3705,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3766,7 +3786,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3778,6 +3799,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3863,7 +3885,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3899,6 +3922,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3918,6 +3942,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3961,12 +3986,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5941,6 +5968,33 @@
       "integrity": "sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==",
       "requires": {
         "moment": ">= 2.9.0"
+      }
+    },
+    "morgan": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
+      "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
+      "requires": {
+        "basic-auth": "~2.0.0",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "ms": {

--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -33,6 +33,7 @@
         "feathers-authentication-hooks": "^0.3.1",
         "feathers-sequelize": "^5.1.3",
         "helmet": "^3.15.0",
+        "morgan": "^1.9.1",
         "passport-custom": "^1.0.5",
         "pg": "^7.6.1",
         "pg-hstore": "^2.3.2",

--- a/services/backend/src/app.js
+++ b/services/backend/src/app.js
@@ -1,6 +1,7 @@
 const compress = require("compression");
 const cors = require("cors");
 const helmet = require("helmet");
+const morgan = require("morgan");
 
 const feathers = require("@feathersjs/feathers");
 const configuration = require("@feathersjs/configuration");
@@ -21,7 +22,8 @@ const app = express(feathers());
 // Load app configuration
 app.configure(configuration());
 
-// Enable security, CORS, compression, and body parsing
+// Enable request logging, security, CORS, compression, and body parsing
+app.use(morgan(":remote-addr - :remote-user [:date[clf]] \":method :url HTTP/:http-version\" :status :res[content-length] :response-time ms"));  // eslint-disable-line
 app.use(helmet());
 app.use(cors());
 app.use(compress());

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -53,12 +53,24 @@ services:
     scraper:
         build:
             context: ./scraper
+        image: scraper
         command: npm start
         ports:
         - 5001:5000
         volumes:
         - ./scraper/:/backend
         - scraper-deps:/backend/node_modules
+    scraper-jira-worker:
+        image: scraper
+        command: npm run worker:jira
+        depends_on:
+        - scraper
+        links:
+        - redis
+    redis:
+        image: redis
+        expose:
+        - 6379
 version: '2'
 volumes:
     backend-database-data:

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -50,6 +50,10 @@ services:
         - 5002:5000
         volumes:
         - ./predictions/:/app
+    redis:
+        image: redis
+        expose:
+        - 6379
     scraper:
         build:
             context: ./scraper
@@ -67,10 +71,6 @@ services:
         - scraper
         links:
         - redis
-    redis:
-        image: redis
-        expose:
-        - 6379
 version: '2'
 volumes:
     backend-database-data:

--- a/services/docker-compose.yaml
+++ b/services/docker-compose.yaml
@@ -60,9 +60,9 @@ services:
         volumes:
         - ./scraper/:/backend
         - scraper-deps:/backend/node_modules
-    scraper-jira-worker:
+    scraper-worker:
         image: scraper
-        command: npm run worker:jira
+        command: npm run worker
         depends_on:
         - scraper
         links:

--- a/services/scraper/package-lock.json
+++ b/services/scraper/package-lock.json
@@ -1187,6 +1187,30 @@
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
         },
+        "bull": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/bull/-/bull-3.10.0.tgz",
+            "integrity": "sha512-LbQsc7c+eYd7IaJD7tS373yKLYttjTfoPZ+9xYYlPM5+gutAjofSTsESOGGyaxyX2lE1dkg+eWhUK5kAPl5Zow==",
+            "requires": {
+                "cron-parser": "^2.7.3",
+                "debuglog": "^1.0.0",
+                "get-port": "^5.0.0",
+                "ioredis": "^4.5.1",
+                "lodash": "^4.17.11",
+                "p-timeout": "^3.1.0",
+                "promise.prototype.finally": "^3.1.0",
+                "semver": "^6.1.1",
+                "util.promisify": "^1.0.0",
+                "uuid": "^3.2.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
+            }
+        },
         "bytes": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -1355,6 +1379,11 @@
                 "strip-ansi": "^4.0.0",
                 "wrap-ansi": "^2.0.0"
             }
+        },
+        "cluster-key-slot": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+            "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
         },
         "co": {
             "version": "4.6.0",
@@ -1537,6 +1566,15 @@
                 "capture-stack-trace": "^1.0.0"
             }
         },
+        "cron-parser": {
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.13.0.tgz",
+            "integrity": "sha512-UWeIpnRb0eyoWPVk+pD3TDpNx3KCFQeezO224oJIkktBrcW6RoAPOx5zIKprZGfk6vcYSmA8yQXItejSaDBhbQ==",
+            "requires": {
+                "is-nan": "^1.2.1",
+                "moment-timezone": "^0.5.25"
+            }
+        },
         "cross-spawn": {
             "version": "6.0.5",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1620,6 +1658,11 @@
                 "ms": "2.0.0"
             }
         },
+        "debuglog": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
+        },
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -1648,7 +1691,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "dev": true,
             "requires": {
                 "object-keys": "^1.0.12"
             }
@@ -1699,6 +1741,11 @@
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
+        },
+        "denque": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+            "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
         },
         "depd": {
             "version": "1.1.2",
@@ -1825,7 +1872,6 @@
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
             "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-            "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.0",
                 "function-bind": "^1.1.1",
@@ -1839,7 +1885,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
             "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-            "dev": true,
             "requires": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
@@ -3017,8 +3062,7 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -3031,6 +3075,14 @@
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
             "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
             "dev": true
+        },
+        "get-port": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.0.0.tgz",
+            "integrity": "sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==",
+            "requires": {
+                "type-fest": "^0.3.0"
+            }
         },
         "get-stream": {
             "version": "3.0.0",
@@ -3174,7 +3226,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -3188,8 +3239,7 @@
         "has-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-            "dev": true
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
         },
         "has-value": {
             "version": "1.0.0",
@@ -3359,6 +3409,37 @@
             "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
             "dev": true
         },
+        "ioredis": {
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.14.0.tgz",
+            "integrity": "sha512-vGzyW9QTdGMjaAPUhMj48Z31mIO5qJLzkbsE5dg+orNi7L5Ph035htmkBZNDTDdDk7kp7e9UJUr+alhRuaWp8g==",
+            "requires": {
+                "cluster-key-slot": "^1.1.0",
+                "debug": "^4.1.1",
+                "denque": "^1.1.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.flatten": "^4.4.0",
+                "redis-commands": "1.5.0",
+                "redis-errors": "^1.2.0",
+                "redis-parser": "^3.0.0",
+                "standard-as-callback": "^2.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
+            }
+        },
         "ipaddr.js": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
@@ -3408,8 +3489,7 @@
         "is-callable": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-            "dev": true
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
         },
         "is-ci": {
             "version": "1.2.1",
@@ -3443,8 +3523,7 @@
         "is-date-object": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-            "dev": true
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
         },
         "is-descriptor": {
             "version": "0.1.6",
@@ -3506,6 +3585,14 @@
             "requires": {
                 "global-dirs": "^0.1.0",
                 "is-path-inside": "^1.0.0"
+            }
+        },
+        "is-nan": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
+            "integrity": "sha1-n69ltvttskt/XAYoR16nH5iEAeI=",
+            "requires": {
+                "define-properties": "^1.1.1"
             }
         },
         "is-npm": {
@@ -3574,7 +3661,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-            "dev": true,
             "requires": {
                 "has": "^1.0.1"
             }
@@ -3600,7 +3686,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-            "dev": true,
             "requires": {
                 "has-symbols": "^1.0.0"
             }
@@ -4560,14 +4645,23 @@
         "lodash": {
             "version": "4.17.14",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-            "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-            "dev": true
+            "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
         },
         "lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
             "dev": true
+        },
+        "lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+        },
+        "lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
         },
         "lodash.sortby": {
             "version": "4.7.0",
@@ -4792,6 +4886,19 @@
             "dev": true,
             "requires": {
                 "minimist": "0.0.8"
+            }
+        },
+        "moment": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+        },
+        "moment-timezone": {
+            "version": "0.5.26",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.26.tgz",
+            "integrity": "sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==",
+            "requires": {
+                "moment": ">= 2.9.0"
             }
         },
         "morgan": {
@@ -5019,8 +5126,7 @@
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
         "object-visit": {
             "version": "1.0.1",
@@ -5035,7 +5141,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-            "dev": true,
             "requires": {
                 "define-properties": "^1.1.2",
                 "es-abstract": "^1.5.1"
@@ -5059,9 +5164,9 @@
             }
         },
         "on-headers": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-            "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
         },
         "once": {
             "version": "1.4.0",
@@ -5153,8 +5258,7 @@
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-            "dev": true
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
         "p-is-promise": {
             "version": "2.1.0",
@@ -5185,6 +5289,14 @@
             "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
             "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
             "dev": true
+        },
+        "p-timeout": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.1.0.tgz",
+            "integrity": "sha512-C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==",
+            "requires": {
+                "p-finally": "^1.0.0"
+            }
         },
         "p-try": {
             "version": "2.2.0",
@@ -5372,6 +5484,16 @@
             "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
             "dev": true
         },
+        "promise.prototype.finally": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
+            "integrity": "sha512-7p/K2f6dI+dM8yjRQEGrTQs5hTQixUAdOGpMEA3+pVxpX5oHKRSKAXyLw9Q9HUWDTdwtoo39dSHGQtN90HcEwQ==",
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.9.0",
+                "function-bind": "^1.1.1"
+            }
+        },
         "prompts": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
@@ -5525,6 +5647,24 @@
             "dev": true,
             "requires": {
                 "util.promisify": "^1.0.0"
+            }
+        },
+        "redis-commands": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
+            "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg=="
+        },
+        "redis-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+            "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+        },
+        "redis-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+            "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+            "requires": {
+                "redis-errors": "^1.0.0"
             }
         },
         "regex-not": {
@@ -6188,6 +6328,11 @@
             "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
             "dev": true
         },
+        "standard-as-callback": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.0.1.tgz",
+            "integrity": "sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg=="
+        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -6531,6 +6676,11 @@
                 "prelude-ls": "~1.1.2"
             }
         },
+        "type-fest": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+            "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+        },
         "type-is": {
             "version": "1.6.16",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
@@ -6704,7 +6854,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-            "dev": true,
             "requires": {
                 "define-properties": "^1.1.2",
                 "object.getownpropertydescriptors": "^2.0.3"
@@ -6718,8 +6867,7 @@
         "uuid": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-            "dev": true
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "validate-npm-package-license": {
             "version": "3.0.4",

--- a/services/scraper/package.json
+++ b/services/scraper/package.json
@@ -8,18 +8,21 @@
         "start": "DEBUG=scraper:* NODE_PATH=src nodemon src/index.js",
         "start:prod": "NODE_PATH=src node src/index.js",
         "jest": "jest",
-        "scrape:contributors": "NODE_PATH=src node src/scrapeTrainingData.js contributors"
+        "scrape:contributors": "NODE_PATH=src node src/scrapeTrainingData.js contributors",
+        "worker:jira": "NODE_PATH=src node src/workers/jiraScrapingWorker.js"
     },
     "dependencies": {
         "axios": "^0.19.0",
         "body-parser": "^1.18.3",
+        "bull": "^3.10.0",
         "cookie-parser": "~1.4.3",
         "cors": "^2.8.5",
         "debug": "~2.6.9",
         "dotenv": "^6.1.0",
         "express": "~4.16.0",
-        "morgan": "~1.9.0",
+        "morgan": "^1.9.1",
         "statuses": "^1.5.0",
+        "uuid": "^3.3.2",
         "winston": "^3.2.1"
     },
     "devDependencies": {

--- a/services/scraper/package.json
+++ b/services/scraper/package.json
@@ -9,7 +9,7 @@
         "start:prod": "NODE_PATH=src node src/index.js",
         "jest": "jest",
         "scrape:contributors": "NODE_PATH=src node src/scrapeTrainingData.js contributors",
-        "worker:jira": "NODE_PATH=src node src/workers/jiraScrapingWorker.js"
+        "worker": "NODE_PATH=src node src/workers/worker.js"
     },
     "dependencies": {
         "axios": "^0.19.0",

--- a/services/scraper/src/app.js
+++ b/services/scraper/src/app.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const cors = require("cors");
-const logger = require("morgan");
+const morgan = require("morgan");
 const bodyParser = require("body-parser");
 const {errorHandler} = require("middleware");
 
@@ -10,7 +10,7 @@ const API_ROOT = "";
 
 const app = express();
 
-app.use(logger("dev"));
+app.use(morgan(":remote-addr - :remote-user [:date[clf]] \":method :url HTTP/:http-version\" :status :res[content-length] :response-time ms"));  // eslint-disable-line
 app.use(express.json());
 app.use(express.urlencoded({extended: false}));
 app.use(bodyParser.json());

--- a/services/scraper/src/components/scraper/scraperController.js
+++ b/services/scraper/src/components/scraper/scraperController.js
@@ -15,8 +15,6 @@ router.get("/contributors", asyncMiddleware(async (req, res) => {
     res.send({status: "success", result});
 }));
 
-router.get("")
-
 router.get("/skills", asyncMiddleware(async (req, res) => {
     req.setTimeout(0);
 

--- a/services/scraper/src/components/scraper/scraperController.js
+++ b/services/scraper/src/components/scraper/scraperController.js
@@ -1,20 +1,22 @@
 const express = require("express");
 const {asyncMiddleware} = require("middleware/");
 const {SkillhubBridge} = require("scrapers/");
+const {jiraScrapingQueue} = require("workers/queues");
 
 const skillhubBridge = new SkillhubBridge();
 
 const router = express.Router();
 
-router.get("/", asyncMiddleware(async (req, res) => {
+router.get("/contributors", asyncMiddleware(async (req, res) => {
     // Remove timeout since this is a (potentially) long running operation
     req.setTimeout(0);
 
-    const result = await skillhubBridge.scrapeToSkillhub();
+    const result = await skillhubBridge.scrapeContributors();
     res.send({status: "success", result});
 }));
 
-// TODO (CDHSH-112): Move this into the main scraper route
+router.get("")
+
 router.get("/skills", asyncMiddleware(async (req, res) => {
     req.setTimeout(0);
 
@@ -25,8 +27,22 @@ router.get("/skills", asyncMiddleware(async (req, res) => {
         return;
     }
 
-    const result = await skillhubBridge.testSkills(org);
+    const result = await skillhubBridge.scrapeSkills(org);
     res.send({status: "success", result});
+}));
+
+router.get("/contributors/jobs", asyncMiddleware(async (req, res) => {
+    const {ids: rawIds} = req.query;
+    const ids = rawIds.split(",");
+
+    const jobs = [];
+
+    for (const id of ids) {
+        const job = await jiraScrapingQueue.getJob(id);
+        jobs.push(job);
+    }
+
+    res.send({status: "success", jobs});
 }));
 
 module.exports = router;

--- a/services/scraper/src/config.js
+++ b/services/scraper/src/config.js
@@ -8,6 +8,7 @@ const {
     JIRA_AUTH_TOKEN = null,
     JIRA_HOST = "https://jira.ised-isde.canada.ca",
     JIRA_PLATFORM = "server",
+    REDIS_PORT = 6379,
     SKILLHUB_API_KEY = "bf3d6ab4879949d5845eb50a31e9e3fa"
 } = process.env;
 
@@ -19,8 +20,8 @@ if (BACKEND_PORT !== "80" && BACKEND_PORT !== "443") {
 
 const REDIS_CONFIG = {
     redis: {
-        port: 6379,
-        host: "redis"
+        host: "redis",
+        port: REDIS_PORT
     }
 };
 

--- a/services/scraper/src/config.js
+++ b/services/scraper/src/config.js
@@ -17,6 +17,13 @@ if (BACKEND_PORT !== "80" && BACKEND_PORT !== "443") {
     BACKEND_URL = `${BACKEND_URL}:${BACKEND_PORT}`;
 }
 
+const REDIS_CONFIG = {
+    redis: {
+        port: 6379,
+        host: "redis"
+    }
+};
+
 module.exports = {
     BACKEND_URL,
     GIT_AUTH_TOKEN,
@@ -25,5 +32,6 @@ module.exports = {
     JIRA_AUTH_TOKEN,
     JIRA_HOST,
     JIRA_PLATFORM,
+    REDIS_CONFIG,
     SKILLHUB_API_KEY
 };

--- a/services/scraper/src/scrapers/SkillhubBridge.js
+++ b/services/scraper/src/scrapers/SkillhubBridge.js
@@ -2,7 +2,7 @@ const axios = require("axios");
 const uuidv4 = require("uuid/v4");
 const {BACKEND_URL, SKILLHUB_API_KEY} = require("config");
 const {jiraScrapingQueue} = require("workers/queues");
-const {chainingPromisePool, logger: baseLogger} = require("utils/");
+const {logger: baseLogger} = require("utils/");
 const GitScraper = require("./GitScraper");
 const JiraScraper = require("./JiraScraper");
 

--- a/services/scraper/src/workers/jiraScrapingWorker.js
+++ b/services/scraper/src/workers/jiraScrapingWorker.js
@@ -1,0 +1,25 @@
+if (process.env.NODE_ENV !== "production") {
+    // In theory, the only time a .env file is present is on a developer's machine
+    // As such, development is the only time that loading the dotenv should be required
+    require("dotenv").config();
+}
+
+const {SkillhubBridge} = require("scrapers/");
+const {logger: baseLogger} = require("utils/");
+const {jiraScrapingQueue} = require("workers/queues");
+
+const logger = baseLogger.child({module: "jiraScrapingWorker"});
+const skillhubBridge = new SkillhubBridge();
+
+const jiraScrapingWorker = async (job) => {
+    const {id} = job;
+    const {project} = job.data;
+
+    logger.info({message: `Starting jira scraping for project ${project.key}`, project, jobId: id});
+    const result = await skillhubBridge.scrapeProjectIssues(project);
+    logger.info({message: `Finished jira scraping for project ${project.key}`, project, jobId: id});
+
+    return result;
+};
+
+jiraScrapingQueue.process(2, jiraScrapingWorker);

--- a/services/scraper/src/workers/jiraScrapingWorker.js
+++ b/services/scraper/src/workers/jiraScrapingWorker.js
@@ -1,12 +1,5 @@
-if (process.env.NODE_ENV !== "production") {
-    // In theory, the only time a .env file is present is on a developer's machine
-    // As such, development is the only time that loading the dotenv should be required
-    require("dotenv").config();
-}
-
 const {SkillhubBridge} = require("scrapers/");
 const {logger: baseLogger} = require("utils/");
-const {jiraScrapingQueue} = require("workers/queues");
 
 const logger = baseLogger.child({module: "jiraScrapingWorker"});
 const skillhubBridge = new SkillhubBridge();
@@ -22,4 +15,4 @@ const jiraScrapingWorker = async (job) => {
     return result;
 };
 
-jiraScrapingQueue.process(2, jiraScrapingWorker);
+module.exports = jiraScrapingWorker;

--- a/services/scraper/src/workers/queues.js
+++ b/services/scraper/src/workers/queues.js
@@ -1,0 +1,8 @@
+const Queue = require("bull");
+const {REDIS_CONFIG} = require("config");
+
+const jiraScrapingQueue = new Queue("jiraScraping", REDIS_CONFIG);
+
+module.exports = {
+    jiraScrapingQueue
+};

--- a/services/scraper/src/workers/worker.js
+++ b/services/scraper/src/workers/worker.js
@@ -1,0 +1,9 @@
+if (process.env.NODE_ENV !== "production") {
+    // In theory, the only time a .env file is present is on a developer's machine
+    // As such, development is the only time that loading the dotenv should be required
+    require("dotenv").config();
+}
+
+const {jiraScrapingQueue} = require("workers/queues");
+
+jiraScrapingQueue.process(2, jiraScrapingWorker);

--- a/services/scraper/src/workers/worker.js
+++ b/services/scraper/src/workers/worker.js
@@ -4,7 +4,19 @@ if (process.env.NODE_ENV !== "production") {
     require("dotenv").config();
 }
 
+/* This file is treated as a script (hence the above dotenv config).
+ * It is used to start a worker instance in a separate container.
+ * This worker instance handles processing jobs for the Jira and Git scraping processes.
+ */
+
 const jiraScrapingWorker = require("./jiraScrapingWorker");
 const {jiraScrapingQueue} = require("./queues");
 
+// Run 2 concurrent copies of the jira scraping process
+// 2 seems like a good number.
+//
+// Technically, we could just spin up more containers of the worker instance,
+// instead of making each instance run concurrent processes, but it's a more
+// efficient use of resources to mix-and-match concurrent processes
+// with multiple container instances.
 jiraScrapingQueue.process(2, jiraScrapingWorker);

--- a/services/scraper/src/workers/worker.js
+++ b/services/scraper/src/workers/worker.js
@@ -4,6 +4,7 @@ if (process.env.NODE_ENV !== "production") {
     require("dotenv").config();
 }
 
-const {jiraScrapingQueue} = require("workers/queues");
+const jiraScrapingWorker = require("./jiraScrapingWorker");
+const {jiraScrapingQueue} = require("./queues");
 
 jiraScrapingQueue.process(2, jiraScrapingWorker);


### PR DESCRIPTION
Changelog:

- The URL for calling the Scraper for the projects/users/contributors has been changed to `/scraper/contributors`.
- The Scraper now uses a set of workers (connected via a Redis queue) for async scraping/processing of the Jira issues.

Other Implementation Details:

- Added two new Kubails services: redis, and scraper-worker.
- Added the `morgan` logger to the Backend and Scraper services so that they log requests in production.
- Modified the 'deployment' manifest templates to work with the new Kubails 'command' option.